### PR TITLE
Add spreadsheet charts

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,9 @@ CORS(app)
 def index():
     return render_template('index.html')
 
+@app.route('/embed_charts')
+def embed_charts():
+    return render_template('embed_charts.html')
 
 app.add_url_rule(
     '/graphql',

--- a/assets/src/components/menu.js
+++ b/assets/src/components/menu.js
@@ -27,8 +27,8 @@ const Logo = () => {
 const MenuItems = () => {
   return (
     <ul>
-      <li><a>Settings</a></li>
-      <li><a>Account</a></li>
+      <li><a href='/graphql'>Queries</a></li>
+      <li><a href='/embed_charts'>Charts</a></li>
     </ul>
   )
 }

--- a/assets/src/styles/_menu.scss
+++ b/assets/src/styles/_menu.scss
@@ -32,6 +32,11 @@
 
     li {
       padding: 0 .5em;
+
+      a {
+        text-decoration: none;
+        color: $neutral-dark;
+      }
     }
   }
 }

--- a/templates/embed_charts.html
+++ b/templates/embed_charts.html
@@ -1,0 +1,5 @@
+<html><head></head>
+<body>
+Replace Me
+</body>
+</html>

--- a/templates/embed_charts.html
+++ b/templates/embed_charts.html
@@ -1,5 +1,12 @@
 <html><head></head>
 <body>
-Replace Me
+    Source: <a href="https://docs.google.com/spreadsheets/d/14nOPKSpBDELt2Qd05_Mn_1dFLwp4mSz9zQLrSoE607A/edit#gid=1872073879">Automatically-updated Google Sheet</a>
+  <div>
+    <iframe width="600" height="371" seamless frameborder="0" scrolling="no" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vR52Jxw2_8WktVSi2ZYSC04MfaqHnyDJgXwyzE5WmRXxMTHbSsXbtI_erXqbZc4tkQ2Nv0hd3n6hw7L/pubchart?oid=143613419&format=interactive"></iframe>
+  </div>
+  <div>
+    <iframe width="375" height="350" seamless frameborder="0" scrolling="no" src="https://docs.google.com/spreadsheets/d/e/2PACX-1vR52Jxw2_8WktVSi2ZYSC04MfaqHnyDJgXwyzE5WmRXxMTHbSsXbtI_erXqbZc4tkQ2Nv0hd3n6hw7L/pubhtml?gid=208447794&single=true&widget=false&headers=false&chrome=false"></iframe><br />
+    <a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vR52Jxw2_8WktVSi2ZYSC04MfaqHnyDJgXwyzE5WmRXxMTHbSsXbtI_erXqbZc4tkQ2Nv0hd3n6hw7L/pub?gid=208447794&single=true&output=pdf">Download PDF</a>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
Adds Queries and Charts menu items as well as a `Charts` page to display embedded spreadsheet charts. 

<img width="1173" alt="screen shot 2018-01-19 at 4 59 35 pm" src="https://user-images.githubusercontent.com/3329425/35173656-2f7dafb4-fd3a-11e7-85c8-e9db687cab7c.png">
